### PR TITLE
Update Builder.php for links on base installation

### DIFF
--- a/myth/Docs/Builder.php
+++ b/myth/Docs/Builder.php
@@ -595,7 +595,7 @@ class Builder implements DocBuilderInterface
         }
 
         // If it's a full local path, get rid of it.
-        if (strpos($href, $site_url) !== false) {
+        if ($site_url !== "/" && strpos($href, $site_url) !== false) {
             $href = str_replace($site_url, '', $href);
         }
 


### PR DESCRIPTION
On a base installation the site_url is set to "/" so the following line in the reformatAnchor method was rewriting "tutorials/blog" to "tutorialsblog" breaking the links for the documentation. 

```
$href = str_replace($site_url, '', $href);
```
